### PR TITLE
roll back part of previous fix for #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.9] - 2016-12-08
+### Fixed
+- Rollback variable part of name-fix (issue #15)
+
 ## [0.0.8] - 2016-12-08
 ### Fixed
 - Fixed name to not show as duplicate (issue #15)
-- Remove `buildLeadVars()` from tests
-- Added support for staging environment
 
 ## [0.0.7] - 2016-08-05
 ### Fixed

--- a/src/batchrobot.coffee
+++ b/src/batchrobot.coffee
@@ -66,8 +66,8 @@ response = (vars, req, res) ->
 
 response.variables = ->
   [
-    { name: 'outcome', type: 'string', description: 'Was the post successful? Success or failure.'},
-    { name: 'reason', type: 'string', description: 'If the post failed this is the error reason.'},
+    { name: 'batchrobot.outcome', type: 'string', description: 'Was the post successful? Success or failure.'},
+    { name: 'batchrobot.reason', type: 'string', description: 'If the post failed this is the error reason.'},
   ]
 
 #


### PR DESCRIPTION
The response.variable names can't change without impacting
existing rules and mappings; not worth fixing at this time.